### PR TITLE
Add process parsing, emotion scoring, and context memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+pytest_cache/
+.pytest_cache/
+.DS_Store

--- a/backend/services/casey.py
+++ b/backend/services/casey.py
@@ -1,0 +1,53 @@
+"""High level orchestration for the Casey interviewer."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .parser import parse_response
+from .emotions import emotional_scores
+from .memory import ContextMemory
+
+
+class Casey:
+    """Minimal interviewer implementation tying together core components.
+
+    The class records conversation turns, extracts process elements and emotional
+    signals and keeps everything in a :class:`ContextMemory` instance.  It does
+    not handle language model interaction directly; instead it focuses on the
+    bookkeeping logic that can be tested offline.
+    """
+
+    def __init__(self, memory: ContextMemory | None = None) -> None:
+        self.memory = memory or ContextMemory()
+
+    def ingest(self, role: str, text: str) -> Dict[str, Dict[str, object]]:
+        """Ingest a new utterance and update memory stores.
+
+        Parameters
+        ----------
+        role:
+            The speaker role, e.g. ``"user"`` or ``"assistant"``.
+        text:
+            Raw natural language text for the turn.
+
+        Returns
+        -------
+        dict
+            Dictionary with ``elements`` and ``emotions`` entries containing the
+            parsed process elements and emotion scores respectively.
+        """
+
+        self.memory.add_turn(role, text)
+        elements = parse_response(text)
+        self.memory.add_process_elements(elements)
+        emotions = emotional_scores(text)
+        self.memory.add_emotions(emotions)
+        return {"elements": elements, "emotions": emotions}
+
+    # Convenience accessors -------------------------------------------------
+    def transcript(self) -> str:
+        return self.memory.transcript()
+
+    def latest_emotion(self) -> Dict[str, float]:
+        return self.memory.latest_emotion()

--- a/backend/services/emotions.py
+++ b/backend/services/emotions.py
@@ -1,0 +1,31 @@
+"""Keyword based emotional scoring used by Casey."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Mapping of emotions to indicative keywords.  The list is intentionally small
+# and purely lexical; it acts as a deterministic stub for more advanced models.
+EMOTION_KEYWORDS = {
+    "frustration": ["frustrated", "annoyed", "irritating", "redo", "pain"],
+    "pride": ["proud", "satisfied", "pleased"],
+    "confusion": ["confused", "unsure", "not sure", "uncertain"],
+    "eagerness": ["eager", "excited", "can't wait", "keen"],
+}
+
+
+def emotional_scores(text: str) -> Dict[str, float]:
+    """Return rudimentary emotion scores for ``text``.
+
+    The score for each emotion is the fraction of its keywords present in the
+    lower-cased text, capped at 1.0.  Absence of keywords yields a score of 0.0.
+    The function is deliberately lightweight and deterministic, making it easy
+    to unit test and safe to run in offline environments.
+    """
+
+    lower = text.lower()
+    scores: Dict[str, float] = {}
+    for emotion, keywords in EMOTION_KEYWORDS.items():
+        hits = sum(1 for k in keywords if k in lower)
+        scores[emotion] = min(hits / len(keywords), 1.0)
+    return scores

--- a/backend/services/memory.py
+++ b/backend/services/memory.py
@@ -74,3 +74,47 @@ class WorkingProcessSlate:
 
     def clear(self) -> None:
         self.active = None
+
+
+class ContextMemory:
+    """Track conversational turns, extracted process elements and emotions.
+
+    The class combines three simple stores:
+
+    * ``session`` – rolling window of the dialogue using :class:`ShortTermMemory`
+    * ``process`` – list of structured process element dictionaries
+    * ``emotions`` – history of detected emotional scores
+
+    It provides tiny helper methods for updating each store and for retrieving
+    common views such as the current transcript or the most recent emotion
+    scores.  No external dependencies are required which keeps this component
+    lightweight and easy to test.
+    """
+
+    def __init__(self, max_turns: int = 12) -> None:
+        self.session = ShortTermMemory(max_turns=max_turns)
+        self.process: List[Dict[str, object]] = []
+        self.emotions: List[Dict[str, float]] = []
+
+    # session memory -----------------------------------------------------
+    def add_turn(self, role: str, content: str) -> None:
+        """Record a new conversation turn."""
+        self.session.add(role, content)
+
+    def transcript(self) -> str:
+        """Return the recent conversation transcript."""
+        return self.session.transcript()
+
+    # process memory -----------------------------------------------------
+    def add_process_elements(self, elements: Dict[str, object]) -> None:
+        """Append extracted process elements to the history."""
+        self.process.append(elements)
+
+    # emotional memory ---------------------------------------------------
+    def add_emotions(self, scores: Dict[str, float]) -> None:
+        """Store detected emotional scores for the latest turn."""
+        self.emotions.append(scores)
+
+    def latest_emotion(self) -> Dict[str, float]:
+        """Return the most recent emotional score dictionary."""
+        return self.emotions[-1] if self.emotions else {}

--- a/backend/services/parser.py
+++ b/backend/services/parser.py
@@ -1,0 +1,61 @@
+"""Simple heuristics for extracting process elements from text.
+
+This module implements a light-weight parser used during conversations with
+Casey.  The goal is not perfect linguistic analysis but to capture obvious
+mentions of steps, actors, tools and decisions so that downstream components can
+reason about the process being described.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+# Regular expressions for different element types -----------------------------
+ACTOR_PATTERN = re.compile(
+    r"\b(manager|supervisor|system|user|staff|employee|customer|receptionist)\b",
+    re.I,
+)
+TOOL_PATTERN = re.compile(
+    r"\b(spreadsheet|software|portal|email|form|tool)\b",
+    re.I,
+)
+DECISION_PATTERN = re.compile(
+    r"\b(if|otherwise|decision|approve|reject)\b",
+    re.I,
+)
+
+
+def parse_response(text: str) -> Dict[str, List[str]]:
+    """Extract rudimentary process elements from ``text``.
+
+    Parameters
+    ----------
+    text:
+        Natural language description of a process fragment.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``steps``, ``actors``, ``tools`` and
+        ``decisions`` lists.  The extraction is intentionally shallow but
+        deterministic which makes it suitable for unit tests and for acting as
+        a placeholder until a more sophisticated NLP pipeline is added.
+    """
+
+    lowered = text.lower()
+
+    # Steps are approximated by splitting into sentences
+    sentences = [s.strip() for s in re.split(r"[.]+\s*", text) if s.strip()]
+
+    actors = sorted({m.group(0).lower() for m in ACTOR_PATTERN.finditer(lowered)})
+    tools = sorted({m.group(0).lower() for m in TOOL_PATTERN.finditer(lowered)})
+
+    decisions = [s for s in sentences if DECISION_PATTERN.search(s)]
+
+    return {
+        "steps": sentences,
+        "actors": actors,
+        "tools": tools,
+        "decisions": decisions,
+    }

--- a/tests/test_emotions.py
+++ b/tests/test_emotions.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.services.emotions import emotional_scores
+
+
+def test_emotional_scores_keywords():
+    text = (
+        "I'm proud of the team but a bit confused by the new tool and it's "
+        "frustrating to redo steps."
+    )
+    scores = emotional_scores(text)
+    assert scores["pride"] > 0
+    assert scores["confusion"] > 0
+    assert scores["frustration"] > 0
+    assert scores["eagerness"] == 0

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,7 +4,7 @@ from pathlib import Path
 # Ensure project root on path for module imports
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from backend.services.memory import ShortTermMemory
+from backend.services.memory import ContextMemory, ShortTermMemory
 
 
 def test_buffer_rollover():
@@ -13,3 +13,15 @@ def test_buffer_rollover():
         mem.add("user", f"u{i}")
     tx = mem.transcript()
     assert "u0" not in tx and "u4" in tx
+
+
+def test_context_memory_tracks_data():
+    mem = ContextMemory(max_turns=2)
+    mem.add_turn("user", "hello")
+    mem.add_process_elements({"steps": ["s1"]})
+    mem.add_emotions({"pride": 1.0})
+    mem.add_turn("assistant", "hi")
+
+    assert "hello" in mem.transcript()
+    assert mem.process[-1]["steps"] == ["s1"]
+    assert mem.latest_emotion()["pride"] == 1.0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.services.parser import parse_response
+
+
+def test_parse_response_extracts_elements():
+    text = (
+        "First the manager checks the form. Then the system sends an email. "
+        "If approved, the supervisor files it."
+    )
+    result = parse_response(text)
+    assert len(result["steps"]) == 3
+    assert "manager" in result["actors"]
+    assert "email" in result["tools"]
+    assert result["decisions"] == ["If approved, the supervisor files it"]


### PR DESCRIPTION
## Summary
- implement `ContextMemory` to track dialogue turns, process elements, and emotional history
- add regex-based `parse_response` for steps, actors, tools, and decisions
- introduce keyword-driven `emotional_scores` and `Casey` orchestrator tying systems together

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcfa8f9b74832f953334b726ab6725