### PR TITLE
feat: add process visualization frontend scaffold

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Process Visualization</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "process-visualization",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "d3": "^7.8.5"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.0"
+  }
+}

--- a/frontend/src/components/AnnotationLayer.jsx
+++ b/frontend/src/components/AnnotationLayer.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+// Renders annotations at specified positions
+export default function AnnotationLayer({ annotations }) {
+  return (
+    <>
+      {annotations.map((a, idx) => (
+        <div
+          key={idx}
+          className="annotation"
+          style={{ left: a.x, top: a.y }}
+        >
+          {a.text}
+        </div>
+      ))}
+    </>
+  );
+}

--- a/frontend/src/components/ProcessVisualizer.jsx
+++ b/frontend/src/components/ProcessVisualizer.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+import useWebSocket from '../hooks/useWebSocket.js';
+import AnnotationLayer from './AnnotationLayer.jsx';
+
+// Simple PDL example data structure
+const samplePDL = {
+  nodes: [
+    { id: 'start', label: 'Start' },
+    { id: 'task1', label: 'Task 1' },
+    { id: 'task2', label: 'Task 2' },
+    { id: 'end', label: 'End' }
+  ],
+  edges: [
+    { source: 'start', target: 'task1' },
+    { source: 'task1', target: 'task2' },
+    { source: 'task2', target: 'end' }
+  ]
+};
+
+export default function ProcessVisualizer() {
+  const svgRef = useRef(null);
+  const [data, setData] = useState(samplePDL);
+  const [annotations, setAnnotations] = useState([]);
+
+  // Handle real-time updates via WebSocket (status changes, etc.)
+  useWebSocket('ws://localhost:8000/ws/process', (msg) => {
+    if (msg.type === 'annotation') {
+      setAnnotations((prev) => [...prev, msg.payload]);
+    }
+    if (msg.type === 'update') {
+      setData(msg.payload);
+    }
+  });
+
+  // Render the flowchart using D3
+  useEffect(() => {
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('*').remove();
+
+    const width = svgRef.current.clientWidth;
+    const height = svgRef.current.clientHeight;
+
+    const simulation = d3
+      .forceSimulation(data.nodes)
+      .force('link', d3.forceLink(data.edges).id((d) => d.id).distance(120))
+      .force('charge', d3.forceManyBody().strength(-400))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    const link = svg
+      .append('g')
+      .attr('stroke', '#999')
+      .selectAll('line')
+      .data(data.edges)
+      .join('line');
+
+    const node = svg
+      .append('g')
+      .selectAll('circle')
+      .data(data.nodes)
+      .join('circle')
+      .attr('r', 20)
+      .attr('fill', '#69b3a2')
+      .call(
+        d3
+          .drag()
+          .on('start', (event, d) => {
+            if (!event.active) simulation.alphaTarget(0.3).restart();
+            d.fx = d.x;
+            d.fy = d.y;
+          })
+          .on('drag', (event, d) => {
+            d.fx = event.x;
+            d.fy = event.y;
+          })
+          .on('end', (event, d) => {
+            if (!event.active) simulation.alphaTarget(0);
+            d.fx = null;
+            d.fy = null;
+          })
+      );
+
+    const labels = svg
+      .append('g')
+      .selectAll('text')
+      .data(data.nodes)
+      .join('text')
+      .text((d) => d.label)
+      .attr('text-anchor', 'middle')
+      .attr('dy', 4)
+      .style('pointer-events', 'none');
+
+    simulation.on('tick', () => {
+      link
+        .attr('x1', (d) => d.source.x)
+        .attr('y1', (d) => d.source.y)
+        .attr('x2', (d) => d.target.x)
+        .attr('y2', (d) => d.target.y);
+
+      node.attr('cx', (d) => d.x).attr('cy', (d) => d.y);
+      labels.attr('x', (d) => d.x).attr('y', (d) => d.y);
+    });
+  }, [data]);
+
+  // Export the current SVG diagram
+  const exportSVG = () => {
+    const svgData = svgRef.current.outerHTML;
+    const blob = new Blob([svgData], { type: 'image/svg+xml;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'process.svg';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div style={{ flex: 1, position: 'relative' }}>
+      <svg ref={svgRef}></svg>
+      <AnnotationLayer annotations={annotations} />
+      <button
+        onClick={exportSVG}
+        style={{ position: 'absolute', top: 10, right: 10 }}
+      >
+        Export SVG
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useWebSocket.js
+++ b/frontend/src/hooks/useWebSocket.js
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+// Simple hook that manages a WebSocket connection and emits incoming messages
+export default function useWebSocket(url, onMessage) {
+  const socketRef = useRef(null);
+
+  useEffect(() => {
+    const socket = new WebSocket(url);
+    socketRef.current = socket;
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        onMessage(data);
+      } catch (err) {
+        console.error('Failed to parse message', err);
+      }
+    };
+    return () => socket.close();
+  }, [url, onMessage]);
+
+  return socketRef;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ProcessVisualizer from './components/ProcessVisualizer.jsx';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ProcessVisualizer />
+  </React.StrictMode>
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,23 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+#root {
+  display: flex;
+  height: 100vh;
+}
+
+svg {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+}
+
+.annotation {
+  position: absolute;
+  background: rgba(255,255,0,0.8);
+  padding: 2px 4px;
+  border-radius: 4px;
+  pointer-events: none;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// Basic Vite configuration for the process visualization frontend
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add initial React + D3 frontend for process visualization
- include WebSocket hook, annotation layer, and SVG export

## Testing
- `pytest`
- `npm install` (fails: 403 Forbidden)
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68bcff29e8a8832f90546d2d9a8f404a