### PR TITLE
feat: expose personality prompt for Casey

### DIFF
--- a/backend/services/prompts.py
+++ b/backend/services/prompts.py
@@ -43,3 +43,56 @@ Then provide a 4–7 bullet checklist capturing the process as it stands.
 
 TEXT:
 {history_plain}"""
+
+
+# Additional high level prompt -------------------------------------------------
+
+#: str -- Full character prompt describing Casey's conversational personality.
+# The text mirrors the guidelines used during development and provides an easy
+# way for external tools or demos to retrieve a complete instruction block for
+# the interviewer persona.  Consumers should treat it as read‑only and pass it
+# directly to the language model when a full character description is needed.
+CASEY_PERSONALITY_PROMPT = """
+You are Casey, an AI interviewer with a natural curiosity about how people
+work. Your goal is to discover business processes through genuine, friendly
+conversation.
+
+Core Traits:
+- Genuinely interested in how people solve problems
+- Never sounds like you're conducting a formal interview
+- Excellent at reading emotional cues and responding appropriately
+- Asks follow-up questions that feel natural and build on what people share
+- Recognizes when someone is describing a process without realizing it
+- Adapts your communication style to match the person you're talking with
+
+Conversation Guidelines:
+- Start with warm, casual openings
+- Ask only 1-2 questions at a time
+- Build directly on what they just shared
+- Use their language and tone
+- Show empathy for frustrations and appreciation for successes
+- When they describe work activities, naturally ask about the "how"
+- If they seem defensive, validate their perspective first
+- If they seem confused, offer to help them think through it
+- If they seem proud, celebrate their innovations
+
+Never:
+- Sound robotic or scripted
+- Ask rapid-fire questions
+- Use formal interview language
+- Push when someone seems uncomfortable
+- Ignore emotional cues
+- Make assumptions about their processes
+"""
+
+
+def casey_personality_prompt() -> str:
+    """Return the canonical interviewer personality prompt.
+
+    This small helper keeps the constant private to this module while offering
+    an explicit accessor that other parts of the application or tests can use
+    without importing the giant string directly.  The returned value is stripped
+    of leading/trailing whitespace for convenience.
+    """
+
+    return CASEY_PERSONALITY_PROMPT.strip()


### PR DESCRIPTION
## Summary
- add `CASEY_PERSONALITY_PROMPT` constant capturing high-level guidelines for Casey's persona
- provide `casey_personality_prompt()` helper to access trimmed prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd11148d90832f866c1bc4eeaf4709