### PR TITLE
feat: adopt chat-inspired dark theme

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import ProcessVisualizer from './components/ProcessVisualizer.jsx';
+
+export default function App() {
+  return (
+    <div className="app">
+      <aside className="sidebar">
+        <div className="sidebar-item">New chat</div>
+        <div className="sidebar-item">Search chats</div>
+        <div className="sidebar-item">Library</div>
+        <div className="sidebar-item">Docs</div>
+        <hr />
+        <div className="sidebar-item">Data Analyst</div>
+        <div className="sidebar-item">MindForge AI</div>
+        <div className="sidebar-item">Resume / Portfolio</div>
+      </aside>
+      <main className="main">
+        <ProcessVisualizer />
+        <div className="welcome-overlay">
+          <h1>Ready when you are.</h1>
+          <div className="input-box">
+            <input type="text" placeholder="Ask anything" />
+            <button>+</button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/components/ProcessVisualizer.jsx
+++ b/frontend/src/components/ProcessVisualizer.jsx
@@ -49,7 +49,7 @@ export default function ProcessVisualizer() {
 
     const link = svg
       .append('g')
-      .attr('stroke', '#999')
+      .attr('stroke', '#555')
       .selectAll('line')
       .data(data.edges)
       .join('line');
@@ -60,7 +60,7 @@ export default function ProcessVisualizer() {
       .data(data.nodes)
       .join('circle')
       .attr('r', 20)
-      .attr('fill', '#69b3a2')
+      .attr('fill', '#10a37f')
       .call(
         d3
           .drag()
@@ -88,7 +88,8 @@ export default function ProcessVisualizer() {
       .text((d) => d.label)
       .attr('text-anchor', 'middle')
       .attr('dy', 4)
-      .style('pointer-events', 'none');
+      .style('pointer-events', 'none')
+      .style('fill', '#fff');
 
     simulation.on('tick', () => {
       link
@@ -116,11 +117,21 @@ export default function ProcessVisualizer() {
 
   return (
     <div style={{ flex: 1, position: 'relative' }}>
-      <svg ref={svgRef}></svg>
+      <svg ref={svgRef} style={{ background: '#212121' }}></svg>
       <AnnotationLayer annotations={annotations} />
       <button
         onClick={exportSVG}
-        style={{ position: 'absolute', top: 10, right: 10 }}
+        style={{
+          position: 'absolute',
+          top: 10,
+          right: 10,
+          background: '#2a2a2a',
+          color: '#e0e0e0',
+          border: 'none',
+          padding: '6px 12px',
+          borderRadius: '4px',
+          cursor: 'pointer'
+        }}
       >
         Export SVG
       </button>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import ProcessVisualizer from './components/ProcessVisualizer.jsx';
+import App from './App.jsx';
 import './styles.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <ProcessVisualizer />
+    <App />
   </React.StrictMode>
 );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,11 +1,88 @@
 body {
   margin: 0;
   font-family: sans-serif;
+  background: #1e1e1e;
+  color: #e0e0e0;
 }
 
 #root {
-  display: flex;
   height: 100vh;
+}
+
+.app {
+  display: flex;
+  height: 100%;
+}
+
+.sidebar {
+  width: 250px;
+  background: #111;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-right: 1px solid #2a2a2a;
+}
+
+.sidebar-item {
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sidebar-item:hover {
+  background: #2a2a2a;
+}
+
+.main {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.welcome-overlay {
+  position: absolute;
+  text-align: center;
+}
+
+.welcome-overlay h1 {
+  font-weight: normal;
+  margin-bottom: 1rem;
+}
+
+.input-box {
+  display: flex;
+  align-items: center;
+  background: #2a2a2a;
+  border: 1px solid #3f3f3f;
+  border-radius: 24px;
+  padding: 0.5rem 1rem;
+  width: 400px;
+  max-width: 80%;
+}
+
+.input-box input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #e0e0e0;
+  outline: none;
+}
+
+.input-box button {
+  background: #3f3f3f;
+  border: none;
+  color: #e0e0e0;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+}
+
+.input-box button:hover {
+  background: #4f4f4f;
 }
 
 svg {
@@ -16,7 +93,7 @@ svg {
 
 .annotation {
   position: absolute;
-  background: rgba(255,255,0,0.8);
+  background: rgba(16, 163, 127, 0.8);
   padding: 2px 4px;
   border-radius: 4px;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- add App layout with sidebar and central prompt input
- style application with dark theme reminiscent of chat UIs
- adjust process visualizer colors to match new theme

## Testing
- `npm --prefix frontend test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd119d154c832f8b21c07afa581919