### PR TITLE
feat: add dynamic conversation flow with tone adaptation

### DIFF
--- a/backend/services/conversation_flow.py
+++ b/backend/services/conversation_flow.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+"""Conversation flow management for Casey.
+
+The :class:`ConversationFlowManager` orchestrates follow-up question
+generation.  It retrieves relevant memories, generates a next question
+with the OpenAI chat model and then rewrites the result to match the
+user's tone via :class:`ToneAdapter`.
+"""
+
+from typing import List
+from .llm_client import chat
+from .memory import summarize_context
+from .tone_adapter import ToneAdapter
+from .vector_memory import VectorMemory
+
+FOLLOWUP_SYSTEM = (
+    "You are Casey, an engaging interviewer helping users map their work. "
+    "Ask short, relevant follow-up questions."
+)
+
+
+class ConversationFlowManager:
+    def __init__(self, memory: VectorMemory | None = None, tone: ToneAdapter | None = None) -> None:
+        self.memory = memory or VectorMemory()
+        self.tone = tone or ToneAdapter()
+
+    def generate(self, conversation_id: str, history: List[str]) -> str:
+        """Return the next follow-up question for ``history``."""
+        if not history:
+            return "Walk me through the very first step and who does it."
+
+        user_text = history[-1]
+        self.tone.update(user_text)
+        self.memory.add(conversation_id, user_text)
+
+        prior = summarize_context(history[:-1], max_len=2000)
+        related = "\n".join(self.memory.search(user_text))
+
+        messages = [
+            {"role": "system", "content": FOLLOWUP_SYSTEM},
+            {
+                "role": "user",
+                "content": (
+                    f"Conversation so far:\n{prior}\n\n"
+                    f"Related notes:\n{related}\n\n"
+                    "Ask the next best question in one sentence."
+                ),
+            },
+        ]
+        question = chat(messages).strip()
+        question = self.tone.apply(question)
+        self.memory.add(conversation_id, question)
+        return question

--- a/backend/services/interviewer.py
+++ b/backend/services/interviewer.py
@@ -1,19 +1,20 @@
+from __future__ import annotations
 from typing import List
-from .llm_client import chat
-from .memory import summarize_context, window_messages
-from .prompts import INTERVIEWER_SYSTEM, interviewer_user
+from .conversation_flow import ConversationFlowManager
 
-def next_questions(history: List[str], persona: str = "default") -> List[str]:
-    history_plain = summarize_context(history, max_len=2000)
-    messages = [
-        {"role": "system", "content": INTERVIEWER_SYSTEM},
-        {"role": "user",   "content": interviewer_user(history_plain, persona)},
-    ]
-    messages = window_messages(messages, max_chars=6000)
-    try:
-        question = chat(messages).strip()
-        if not question or len(question) < 3:
-            question = "Walk me through the very next step and who does it."
-    except Exception:
-        question = "Walk me through the very next step and who does it."
+_manager = ConversationFlowManager()
+
+
+def next_questions(history: List[str], conversation_id: str = "default") -> List[str]:
+    """Return the next question Casey should ask.
+
+    Parameters
+    ----------
+    history:
+        Full conversation transcript with the most recent user message
+        placed at the end of the list.
+    conversation_id:
+        Identifier used for vector-memory storage.
+    """
+    question = _manager.generate(conversation_id, history)
     return [question]

--- a/backend/services/llm_client.py
+++ b/backend/services/llm_client.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any, Generator, Optional
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY", "")
 BASE_URL = os.getenv("OPENAI_BASE_URL", "").rstrip("/")
 TIMEOUT = float(os.getenv("LLM_REQUEST_TIMEOUT", "45"))
-MODEL = os.getenv("LLM_MODEL", "gpt-4o-mini")
+MODEL = os.getenv("LLM_MODEL", "gpt-5.1")
 TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", "0.2"))
 
 OPENAI_URL = f"{BASE_URL or 'https://api.openai.com'}/v1/chat/completions"

--- a/backend/services/tone_adapter.py
+++ b/backend/services/tone_adapter.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+"""Tone adaptation utilities for Casey.
+
+This module exposes :class:`ToneAdapter` which analyses a user's latest
+message to detect their communication style and then rewrites Casey's
+responses to mirror that tone.  No persona selection is required; the
+style is inferred on the fly from the dialogue.
+"""
+
+from typing import Optional
+from .llm_client import chat
+
+
+class ToneAdapter:
+    """Detect and mirror the user's tone in Casey's responses."""
+
+    def __init__(self) -> None:
+        self.style: Optional[str] = None
+
+    def update(self, user_message: str) -> None:
+        """Derive a short description of the user's tone.
+
+        The description is stored and later used to rewrite Casey's
+        follow‑up questions in a matching style.
+        """
+
+        prompt = [
+            {"role": "system", "content": "Describe the tone and style of the user's message in a few words."},
+            {"role": "user", "content": user_message},
+        ]
+        try:
+            self.style = chat(prompt).strip()
+        except Exception:
+            self.style = None
+
+    def apply(self, assistant_message: str) -> str:
+        """Rewrite ``assistant_message`` in the inferred style."""
+        if not self.style:
+            return assistant_message
+        prompt = [
+            {
+                "role": "system",
+                "content": f"Rewrite the assistant response using this tone: {self.style}"
+            },
+            {"role": "user", "content": assistant_message},
+        ]
+        try:
+            return chat(prompt).strip()
+        except Exception:
+            return assistant_message

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+"""Vector-based memory layer for Casey conversations.
+
+The implementation provides a thin abstraction over external vector
+stores such as Pinecone or Weaviate while falling back to a simple
+in-memory list when those services are unavailable.  Embeddings are
+retrieved from the OpenAI API.
+"""
+
+from typing import List, Tuple
+import os
+import math
+
+import httpx
+
+try:  # Optional dependencies
+    import pinecone
+except Exception:  # pragma: no cover - optional
+    pinecone = None
+
+try:  # Optional dependencies
+    import weaviate
+except Exception:  # pragma: no cover - optional
+    weaviate = None
+
+from .llm_client import _auth_headers, BASE_URL, TIMEOUT
+
+EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
+EMBED_URL = f"{BASE_URL or 'https://api.openai.com'}/v1/embeddings"
+
+
+def _embed(text: str) -> List[float]:
+    payload = {"input": text, "model": EMBED_MODEL}
+    with httpx.Client(timeout=TIMEOUT) as client:
+        r = client.post(EMBED_URL, headers=_auth_headers(), json=payload)
+        r.raise_for_status()
+        data = r.json()
+        return data["data"][0]["embedding"]
+
+
+class VectorMemory:
+    """Store and retrieve conversation snippets via vector similarity."""
+
+    def __init__(self, index_name: str = "casey-memory", dimension: int = 1536):
+        self.provider = os.getenv("VECTOR_DB", "").lower()
+        self.index_name = index_name
+        if self.provider == "pinecone" and pinecone:
+            pinecone.init(
+                api_key=os.getenv("PINECONE_API_KEY", ""),
+                environment=os.getenv("PINECONE_ENV", ""),
+            )
+            if index_name not in pinecone.list_indexes():
+                pinecone.create_index(name=index_name, dimension=dimension)
+            self.index = pinecone.Index(index_name)
+        elif self.provider == "weaviate" and weaviate:
+            url = os.getenv("WEAVIATE_URL", "http://localhost:8080")
+            self.client = weaviate.Client(url)
+            self.index = index_name
+        else:
+            self.store: List[Tuple[str, List[float], str]] = []
+
+    # ------------------------------------------------------------------
+    def add(self, conv_id: str, text: str) -> None:
+        vec = _embed(text)
+        if self.provider == "pinecone" and pinecone:
+            self.index.upsert([(conv_id, vec, {"text": text})])
+        elif self.provider == "weaviate" and weaviate:
+            self.client.batch.add_data_object(
+                {"conversation": conv_id, "text": text},
+                class_name=self.index,
+                vector=vec,
+            )
+        else:
+            self.store.append((conv_id, vec, text))
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, top_k: int = 5) -> List[str]:
+        vec = _embed(query)
+        if self.provider == "pinecone" and pinecone:
+            res = self.index.query(vec, top_k=top_k, include_metadata=True)
+            return [m["metadata"]["text"] for m in res.get("matches", [])]
+        elif self.provider == "weaviate" and weaviate:
+            result = (
+                self.client.query.get(self.index, ["text"])
+                .with_near_vector({"vector": vec})
+                .with_limit(top_k)
+                .do()
+            )
+            return [r["text"] for r in result["data"]["Get"].get(self.index, [])]
+        else:
+            # naive cosine similarity
+            def cosine(u: List[float], v: List[float]) -> float:
+                dot = sum(a * b for a, b in zip(u, v))
+                nu = math.sqrt(sum(a * a for a in u))
+                nv = math.sqrt(sum(b * b for b in v))
+                return dot / (nu * nv + 1e-10)
+
+            scored = [
+                (cosine(vec, v), text)
+                for _cid, v, text in self.store
+            ]
+            scored.sort(reverse=True)
+            return [text for _s, text in scored[:top_k]]


### PR DESCRIPTION
## Summary
- introduce `ConversationFlowManager` with vector memory and tone mirroring
- update APIs to generate follow-up questions using conversation ID
- default OpenAI model updated to `gpt-5.1`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd3dca0244832f9ae9661f9dc61121