### PR TITLE
chore: add pre-commit dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ langchain = "^0.1.17"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2.0"
+pre-commit = "^3.7.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary
- add pre-commit to poetry dev dependencies so hooks are available

## Testing
- `pytest -q`
- `SECRET_KEY=1 DATABASE_URL=2 GOOGLE_OAUTH_CLIENT_ID=3 GOOGLE_OAUTH_CLIENT_SECRET=4 GITHUB_OAUTH_CLIENT_ID=5 GITHUB_OAUTH_CLIENT_SECRET=6 STRIPE_PUBLIC_KEY=7 STRIPE_SECRET_KEY=8 bash ops/scripts/check-env.sh`
- `pre-commit run --files Makefile` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd934b2474832f9d4b6ae7eb0c8b85