### PR TITLE
fix: correct backend integrations import path

### DIFF
--- a/apps/backend/db.py
+++ b/apps/backend/db.py
@@ -1,4 +1,4 @@
-from integrations.database import engine, SessionLocal, init_db
+from packages.integrations.database import engine, SessionLocal, init_db
 from .models import Base
 
 # Initialize tables on startup

--- a/apps/backend/middleware.py
+++ b/apps/backend/middleware.py
@@ -5,7 +5,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
-from integrations.database import SessionLocal
+from packages.integrations.database import SessionLocal
 from .services.models import Asset, AssetVisibility
 
 


### PR DESCRIPTION
## Summary
- import the integrations package from its new location under `packages`

## Testing
- `pytest -q`
- `SECRET_KEY=1 DATABASE_URL=2 GOOGLE_OAUTH_CLIENT_ID=3 GOOGLE_OAUTH_CLIENT_SECRET=4 GITHUB_OAUTH_CLIENT_ID=5 GITHUB_OAUTH_CLIENT_SECRET=6 STRIPE_PUBLIC_KEY=7 STRIPE_SECRET_KEY=8 bash ops/scripts/check-env.sh`
- `pre-commit run --files apps/backend/middleware.py apps/backend/db.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd95bd4a98832f9ac771e237d9e1fd