### PR TITLE
Add scalable Rust engine crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ apps/frontend/node_modules/
 dist/
 build/
 .env
+**/target/

--- a/scalable_engine/Cargo.toml
+++ b/scalable_engine/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "scalable_engine"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+num_cpus = "1"

--- a/scalable_engine/src/lib.rs
+++ b/scalable_engine/src/lib.rs
@@ -1,0 +1,60 @@
+use tokio::runtime::{Builder, Runtime};
+use futures::future::join_all;
+
+/// Engine provides a wrapper around a Tokio runtime capable of executing
+/// many tasks concurrently.
+pub struct Engine {
+    runtime: Runtime,
+}
+
+impl Engine {
+    /// Create a new engine with the given number of worker threads.
+    pub fn new(worker_threads: usize) -> Self {
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(worker_threads)
+            .enable_all()
+            .build()
+            .expect("failed to build runtime");
+
+        Self { runtime }
+    }
+
+    /// Create a new engine sized to the available CPU count.
+    pub fn new_auto() -> Self {
+        let workers = num_cpus::get();
+        Self::new(workers)
+    }
+
+    /// Run multiple async tasks and collect their results.
+    pub fn run_tasks<F, T>(&self, tasks: Vec<F>) -> Vec<T>
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.runtime.block_on(async { join_all(tasks).await })
+    }
+
+    /// Spawn a single future onto the engine.
+    pub fn spawn<F, T>(&self, future: F) -> tokio::task::JoinHandle<T>
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        self.runtime.spawn(future)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runs_many_tasks() {
+        let engine = Engine::new(4);
+        let tasks = (0..10)
+            .map(|i| async move { i + 1 })
+            .collect::<Vec<_>>();
+        let results = engine.run_tasks(tasks);
+        assert_eq!(results, (1..=10).collect::<Vec<_>>());
+    }
+}


### PR DESCRIPTION
## Summary
- add `scalable_engine` crate using Tokio runtime for concurrent task execution
- ignore Rust build artifacts in `.gitignore`

## Testing
- `cargo test` *(fails: failed to download crates from index, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9b05c428832fb2a0b0d952592f94