### PR TITLE
fix: address backend import paths and makefile tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,16 @@ dev:
 fmt:
 	pre-commit run --all-files
 
-test:
-        pytest -q
+test: .dev-venv
+	pytest -q
 
-lint:
-        ruff check apps packages
-        pnpm -C $(DEV_FRONTEND) lint
+lint: .dev-venv
+	ruff check apps packages
+	pnpm -C $(DEV_FRONTEND) lint
 
-typecheck:
-        mypy $(DEV_BACKEND)
-        pnpm -C $(DEV_FRONTEND) typecheck
+typecheck: .dev-venv
+	mypy $(DEV_BACKEND)
+	pnpm -C $(DEV_FRONTEND) typecheck
 
 build:
 	pnpm -C $(DEV_FRONTEND) build
@@ -36,5 +36,5 @@ seed:
 	python ops/seed.py
 
 hooks:
-        pre-commit install
-        pre-commit install --hook-type commit-msg
+	pre-commit install
+	pre-commit install --hook-type commit-msg

--- a/apps/backend/app.py
+++ b/apps/backend/app.py
@@ -11,9 +11,9 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from .middleware import AssetAccessMiddleware
 
-# Fix: Use absolute imports instead of relative imports
+# Include optional workforce router if available
 try:
-    from routers import workforce
+    from .routers import workforce
     WORKFORCE_ROUTER_AVAILABLE = True
 except ImportError:
     print("⚠️  Workforce router not available")

--- a/apps/backend/database.py
+++ b/apps/backend/database.py
@@ -1,0 +1,8 @@
+"""Database integration wrapper for backend services."""
+
+try:
+    from packages.integrations.database import engine, SessionLocal, init_db
+except ModuleNotFoundError as e:
+    raise ModuleNotFoundError(
+        "The integrations package is required: 'packages.integrations.database' not found."
+    ) from e

--- a/apps/backend/db.py
+++ b/apps/backend/db.py
@@ -1,4 +1,6 @@
-from packages.integrations.database import engine, SessionLocal, init_db
+"""Database session handling for the backend app."""
+
+from .database import engine, SessionLocal, init_db
 from .models import Base
 
 # Initialize tables on startup

--- a/apps/backend/routers/skills.py
+++ b/apps/backend/routers/skills.py
@@ -1,11 +1,11 @@
 from typing import Dict, List
+
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
-from ..services import models
 from .. import schemas
 from ..db import get_db
-from ..services import skill_matrix
+from ..services import models, skill_matrix
 
 router = APIRouter(prefix="/skills", tags=["skills"])
 

--- a/apps/backend/services/skill_matrix.py
+++ b/apps/backend/services/skill_matrix.py
@@ -1,8 +1,9 @@
 """Queries for the skill matrix and growth ledger."""
 
 from typing import Dict, List
-from sqlalchemy.orm import Session
+
 from sqlalchemy import func
+from sqlalchemy.orm import Session
 
 from .models import Skill, SkillEvidence
 


### PR DESCRIPTION
## Summary
- fix backend import paths to use local modules and add a database wrapper
- correct router imports and skill matrix helpers for new monorepo layout
- enforce tab indentation with `.dev-venv` dependencies in Makefile tasks

## Testing
- `pytest -q` *(fails: No module named 'yaml'; network restrictions prevent installing pyyaml)*
- `SECRET_KEY=1 DATABASE_URL=2 GOOGLE_OAUTH_CLIENT_ID=3 GOOGLE_OAUTH_CLIENT_SECRET=4 GITHUB_OAUTH_CLIENT_ID=5 GITHUB_OAUTH_CLIENT_SECRET=6 STRIPE_PUBLIC_KEY=7 STRIPE_SECRET_KEY=8 bash ops/scripts/check-env.sh`
- `pre-commit run --files Makefile apps/backend/database.py apps/backend/db.py apps/backend/app.py apps/backend/routers/skills.py apps/backend/services/skill_matrix.py apps/backend/middleware.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9e82c36c832f8bf81eb5a271d843