### PR TITLE
ci: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "dummy build log" > build.log
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-log
+          path: build.log


### PR DESCRIPTION
## Summary
- add CI workflow using upload-artifact v4

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdde1d8274832f831bec01c47c1c43