### PR TITLE
chore: ensure pnpm installation in CI and run tests if present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@ jobs:
         with:
           node-version: 20
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - run: npm install -g pnpm@8
       - run: pnpm install
-      - run: pnpm test || echo "no tests"
+      - run: pnpm test --if-present
       - run: mkdir -p artifact && echo "placeholder" > artifact/placeholder.txt
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- install pnpm globally in CI workflow
- run pnpm tests only when defined to avoid masking failures

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde1df09dc832fb5adfa37ebdf30fd