### PR TITLE
chore: ensure pnpm setup in CI and conditional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           version: 8
       - run: pnpm install
-      - run: pnpm test || echo "no tests"
+      - run: pnpm test --if-present
       - run: mkdir -p artifact && echo "placeholder" > artifact/placeholder.txt
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- install pnpm via pnpm/action-setup in CI
- run pnpm tests only when defined to avoid masking failures

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde1df09dc832fb5adfa37ebdf30fd