### PR TITLE
test: expand CI workflow for apps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,71 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        app: [backend, frontend]
+    env:
+      APP_DIR: apps/${{ matrix.app }}
     steps:
       - uses: actions/checkout@v4
-      - run: echo "dummy build log" > build.log
-      - uses: actions/upload-artifact@v4
+      - name: Setup Node
+        if: matrix.app == 'frontend'
+        uses: actions/setup-node@v4
         with:
-          name: build-log
-          path: build.log
+          node-version: '20'
+      - name: Setup Python
+        if: matrix.app == 'backend'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        working-directory: ${{ env.APP_DIR }}
+        run: |
+          if [ "${{ matrix.app }}" = "backend" ]; then
+            poetry install
+          else
+            pnpm install
+          fi
+      - name: Lint
+        working-directory: ${{ env.APP_DIR }}
+        run: |
+          if [ "${{ matrix.app }}" = "backend" ]; then
+            poetry run flake8 .
+          else
+            pnpm run lint --if-present
+          fi
+      - name: Typecheck
+        working-directory: ${{ env.APP_DIR }}
+        run: |
+          if [ "${{ matrix.app }}" = "backend" ]; then
+            poetry run mypy .
+          else
+            pnpm run typecheck --if-present
+          fi
+      - name: Test
+        working-directory: ${{ env.APP_DIR }}
+        run: |
+          if [ "${{ matrix.app }}" = "backend" ]; then
+            poetry run pytest
+          else
+            pnpm test --if-present
+          fi
+      - name: Build
+        working-directory: ${{ env.APP_DIR }}
+        run: |
+          if [ "${{ matrix.app }}" = "backend" ]; then
+            poetry build
+          else
+            pnpm run build --if-present
+          fi
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.app }}-dist
+          path: ${{ env.APP_DIR }}/dist


### PR DESCRIPTION
## Summary
- build matrix CI workflow for backend and frontend
- run lint, type check, test, and build steps for each app
- upload artifacts for each app's dist output

## Testing
- `pnpm install`
- `poetry install`
- `make build`
- `make test` *(fails: Table 'project_comments' is already defined for this MetaData instance)*
- `poetry run ruff check apps packages` *(fails: Found 91 errors)*
- `poetry run mypy apps/backend` *(fails: Unterminated string literal)*

------
https://chatgpt.com/codex/tasks/task_e_68be2309c5cc832f91cf3b0ddf3077d8