### PR TITLE
Simplify dashboard UI

### DIFF
--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -1,5 +1,14 @@
+import React from 'react';
+import BusinessDashboard from './components/BusinessDashboard.jsx';
 
+function App() {
+  return (
+    <div className="app">
+      <main>
+        <BusinessDashboard />
       </main>
     </div>
   );
 }
+
+export default App;

--- a/apps/frontend/src/components/BusinessDashboard.css
+++ b/apps/frontend/src/components/BusinessDashboard.css
@@ -30,38 +30,6 @@
   margin-bottom: 2rem;
 }
 
-.dashboard-tabs {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 2rem;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  padding: 4px;
-  backdrop-filter: blur(10px);
-}
-
-.tab {
-  background: none;
-  border: none;
-  color: white;
-  padding: 12px 24px;
-  border-radius: 8px;
-  cursor: pointer;
-  font-weight: 500;
-  transition: all 0.3s ease;
-  margin: 0 4px;
-}
-
-.tab:hover {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.tab.active {
-  background: rgba(255, 255, 255, 0.2);
-  backdrop-filter: blur(20px);
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-}
-
 .dashboard-content {
   background: rgba(255, 255, 255, 0.05);
   border-radius: 16px;
@@ -209,127 +177,6 @@
   opacity: 0.8;
 }
 
-/* Opportunities Tab */
-.opportunities-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.opportunity-card {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  padding: 1.5rem;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  transition: transform 0.3s ease;
-}
-
-.opportunity-card:hover {
-  transform: translateY(-4px);
-}
-
-.opportunity-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 1rem;
-}
-
-.opportunity-header h3 {
-  margin: 0;
-  font-size: 1.1rem;
-  line-height: 1.4;
-}
-
-.urgency {
-  background: rgba(255, 255, 255, 0.2);
-  padding: 0.25rem 0.75rem;
-  border-radius: 20px;
-  font-size: 0.75rem;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.urgency.high {
-  background: rgba(239, 68, 68, 0.3);
-}
-
-.urgency.medium {
-  background: rgba(245, 158, 11, 0.3);
-}
-
-.urgency.low {
-  background: rgba(34, 197, 94, 0.3);
-}
-
-.opportunity-details {
-  margin-bottom: 1.5rem;
-}
-
-.opportunity-type {
-  font-size: 0.9rem;
-  opacity: 0.8;
-  margin: 0 0 0.5rem 0;
-  text-transform: capitalize;
-}
-
-.opportunity-budget {
-  font-weight: 600;
-  font-size: 1.1rem;
-  margin: 0;
-}
-
-.opportunity-action {
-  background: linear-gradient(45deg, #10b981, #34d399);
-  color: white;
-  border: none;
-  padding: 0.75rem 1.5rem;
-  border-radius: 8px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  width: 100%;
-}
-
-.opportunity-action:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.4);
-}
-
-/* Intelligence Tab */
-.intelligence-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
-}
-
-.intelligence-card {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  padding: 1.5rem;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.intelligence-card h3 {
-  margin: 0 0 1rem 0;
-  font-size: 1.1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.insight-content p {
-  margin: 0 0 0.75rem 0;
-  line-height: 1.5;
-  font-size: 0.9rem;
-}
-
-.insight-content p:last-child {
-  margin-bottom: 0;
-}
-
 /* Footer */
 .dashboard-footer {
   text-align: center;
@@ -369,14 +216,6 @@
   50% { opacity: 0.5; }
 }
 
-.no-opportunities {
-  text-align: center;
-  padding: 3rem;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  backdrop-filter: blur(10px);
-}
-
 /* Responsive Design */
 @media (max-width: 768px) {
   .business-dashboard {
@@ -387,24 +226,8 @@
     font-size: 2rem;
   }
   
-  .dashboard-tabs {
-    flex-direction: column;
-    gap: 0.5rem;
-  }
-  
-  .tab {
-    width: 100%;
-    text-align: center;
-  }
-  
   .summary-cards {
     grid-template-columns: 1fr;
-  }
-  
-  .opportunity-header {
-    flex-direction: column;
-    gap: 0.5rem;
-    align-items: flex-start;
   }
   
   .milestone-header {
@@ -412,4 +235,11 @@
     align-items: flex-start;
     gap: 0.5rem;
   }
+}
+
+/* Unified dashboard layout */
+.unified-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 4rem;
 }

--- a/apps/frontend/src/components/BusinessDashboard.jsx
+++ b/apps/frontend/src/components/BusinessDashboard.jsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
+import './BusinessDashboard.css';
 
 const BusinessDashboard = () => {
   const [dashboardData, setDashboardData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [activeTab, setActiveTab] = useState('overview');
 
   useEffect(() => {
     fetchDashboardData();
@@ -37,7 +37,7 @@ const BusinessDashboard = () => {
     );
   }
 
-  const { summary, quick_wins, opportunities, intelligence, next_milestones } = dashboardData;
+  const { summary, quick_wins, next_milestones } = dashboardData;
 
   return (
     <div className="business-dashboard">
@@ -46,178 +46,75 @@ const BusinessDashboard = () => {
         <p className="subtitle">Transforming your creative business with intelligent insights</p>
       </header>
 
-      <div className="dashboard-tabs">
-        <button 
-          className={`tab ${activeTab === 'overview' ? 'active' : ''}`}
-          onClick={() => setActiveTab('overview')}
-        >
-          Overview
-        </button>
-        <button 
-          className={`tab ${activeTab === 'opportunities' ? 'active' : ''}`}
-          onClick={() => setActiveTab('opportunities')}
-        >
-          Opportunities
-        </button>
-        <button 
-          className={`tab ${activeTab === 'intelligence' ? 'active' : ''}`}
-          onClick={() => setActiveTab('intelligence')}
-        >
-          Intelligence
-        </button>
-      </div>
-
       <div className="dashboard-content">
-        {activeTab === 'overview' && (
-          <div className="overview-tab">
-            <div className="summary-cards">
-              <div className="summary-card opportunities">
-                <div className="card-icon">💼</div>
-                <div className="card-content">
-                  <h3>{summary.active_opportunities}</h3>
-                  <p>Active Opportunities</p>
-                </div>
-              </div>
-              
-              <div className="summary-card revenue">
-                <div className="card-icon">💰</div>
-                <div className="card-content">
-                  <h3>{summary.revenue_potential}</h3>
-                  <p>Revenue Potential</p>
-                </div>
-              </div>
-              
-              <div className="summary-card optimization">
-                <div className="card-icon">📈</div>
-                <div className="card-content">
-                  <h3>{Math.round(summary.optimization_score * 100)}%</h3>
-                  <p>Optimization Score</p>
-                </div>
-              </div>
-              
-              <div className="summary-card stage">
-                <div className="card-icon">🎯</div>
-                <div className="card-content">
-                  <h3>{summary.business_stage}</h3>
-                  <p>Business Stage</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="quick-wins-section">
-              <h2>🚀 Quick Wins</h2>
-              <p className="section-subtitle">High-impact actions you can take today</p>
-              <ul className="quick-wins-list">
-                {quick_wins.map((win, index) => (
-                  <li key={index} className="quick-win-item">
-                    <span className="win-icon">✅</span>
-                    {win}
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div className="milestones-section">
-              <h2>🎯 Next Milestones</h2>
-              <p className="section-subtitle">Your path to business growth</p>
-              <div className="milestones-list">
-                {next_milestones.map((milestone, index) => (
-                  <div key={index} className="milestone-item">
-                    <div className="milestone-header">
-                      <h3>{milestone.milestone}</h3>
-                      <span className="milestone-eta">{milestone.eta}</span>
-                    </div>
-                    <div className="progress-bar">
-                      <div 
-                        className="progress-fill" 
-                        style={{ width: `${milestone.progress * 100}%` }}
-                      ></div>
-                    </div>
-                    <span className="progress-text">{Math.round(milestone.progress * 100)}% complete</span>
-                  </div>
-                ))}
-              </div>
+        <div className="summary-cards">
+          <div className="summary-card opportunities">
+            <div className="card-icon">💼</div>
+            <div className="card-content">
+              <h3>{summary.active_opportunities}</h3>
+              <p>Active Opportunities</p>
             </div>
           </div>
-        )}
 
-        {activeTab === 'opportunities' && (
-          <div className="opportunities-tab">
-            <h2>💼 Business Opportunities</h2>
-            <p className="section-subtitle">Curated opportunities matched to your skills</p>
-            
-            {opportunities.length === 0 ? (
-              <div className="no-opportunities">
-                <p>No opportunities found. Let's chat about your skills to find better matches!</p>
-              </div>
-            ) : (
-              <div className="opportunities-list">
-                {opportunities.map((opp, index) => (
-                  <div key={index} className="opportunity-card">
-                    <div className="opportunity-header">
-                      <h3>{opp.title}</h3>
-                      <span className={`urgency ${opp.urgency}`}>{opp.urgency} priority</span>
-                    </div>
-                    <div className="opportunity-details">
-                      <p className="opportunity-type">{opp.type.replace('_', ' ')}</p>
-                      <p className="opportunity-budget">{opp.budget_range}</p>
-                    </div>
-                    <button className="opportunity-action">View Details</button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {activeTab === 'intelligence' && (
-          <div className="intelligence-tab">
-            <h2>🧠 Business Intelligence</h2>
-            <p className="section-subtitle">Data-driven insights about your business</p>
-            
-            <div className="intelligence-grid">
-              {intelligence.performance_insights && (
-                <div className="intelligence-card">
-                  <h3>📊 Performance Insights</h3>
-                  <div className="insight-content">
-                    <p><strong>Revenue Trends:</strong> {intelligence.performance_insights.revenue_trends?.monthly_growth || 'Analyzing...'}</p>
-                    <p><strong>Client Analysis:</strong> {intelligence.performance_insights.client_analysis?.repeat_rate || 'Building data...'}</p>
-                  </div>
-                </div>
-              )}
-              
-              <div className="intelligence-card">
-                <h3>🎯 Growth Trajectory</h3>
-                <div className="insight-content">
-                  <p><strong>Current Stage:</strong> {intelligence.growth_trajectory?.current_stage || summary.business_stage}</p>
-                  <p><strong>Growth Potential:</strong> {intelligence.growth_trajectory?.growth_multiplier || '2-3x revenue'}</p>
-                </div>
-              </div>
-              
-              {intelligence.risk_assessment && (
-                <div className="intelligence-card">
-                  <h3>⚠️ Risk Assessment</h3>
-                  <div className="insight-content">
-                    {intelligence.risk_assessment.slice(0, 2).map((risk, index) => (
-                      <p key={index}><strong>{risk.risk}:</strong> {risk.impact} impact</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-              
-              {intelligence.optimization_opportunities && (
-                <div className="intelligence-card">
-                  <h3>🚀 Optimization</h3>
-                  <div className="insight-content">
-                    {intelligence.optimization_opportunities.slice(0, 2).map((opp, index) => (
-                      <p key={index}><strong>{opp.area}:</strong> {opp.potential}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
+          <div className="summary-card revenue">
+            <div className="card-icon">💰</div>
+            <div className="card-content">
+              <h3>{summary.revenue_potential}</h3>
+              <p>Revenue Potential</p>
             </div>
           </div>
-        )}
+
+          <div className="summary-card optimization">
+            <div className="card-icon">📈</div>
+            <div className="card-content">
+              <h3>{Math.round(summary.optimization_score * 100)}%</h3>
+              <p>Optimization Score</p>
+            </div>
+          </div>
+
+          <div className="summary-card stage">
+            <div className="card-icon">🎯</div>
+            <div className="card-content">
+              <h3>{summary.business_stage}</h3>
+              <p>Business Stage</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="quick-wins-section">
+          <h2>🚀 Quick Wins</h2>
+          <p className="section-subtitle">High-impact actions you can take today</p>
+          <ul className="quick-wins-list">
+            {quick_wins.map((win, index) => (
+              <li key={index} className="quick-win-item">
+                <span className="win-icon">✅</span>
+                {win}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="milestones-section">
+          <h2>🎯 Next Milestones</h2>
+          <p className="section-subtitle">Your path to business growth</p>
+          <div className="milestones-list">
+            {next_milestones.map((milestone, index) => (
+              <div key={index} className="milestone-item">
+                <div className="milestone-header">
+                  <h3>{milestone.milestone}</h3>
+                  <span className="milestone-eta">{milestone.eta}</span>
+                </div>
+                <div className="progress-bar">
+                  <div
+                    className="progress-fill"
+                    style={{ width: `${milestone.progress * 100}%` }}
+                  ></div>
+                </div>
+                <span className="progress-text">{Math.round(milestone.progress * 100)}% complete</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
 
       <footer className="dashboard-footer">


### PR DESCRIPTION
## Summary
- render business dashboard directly from main app for a single entry point
- remove unused UnifiedDashboard and CreatorDashboard components
- load dashboard styles within BusinessDashboard component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pnpm --filter process-visualization build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be47764d84832f9c74f69e722762dc