### PR TITLE
Add macOS startup script for MindForge

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Apple-specific startup script for MindForge
+# Delegates to the cross-platform run.sh to launch the backend server
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# Ensure run.sh is executable and present
+if [ ! -x run.sh ]; then
+    chmod +x run.sh
+fi
+
+./run.sh "$@"


### PR DESCRIPTION
## Summary
- Provide `startup.sh` that launches the app on macOS by delegating to existing `run.sh`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5110efdc832f9ff1a0799f021de7