### PR TITLE
fix: proper poetry dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 description = "MindForge monorepo"
 authors = ["MindForge Contributors"]
 
+[tool.poetry.dependencies]
+python = "^3.10"
 fastapi = "^0.115.0"
 uvicorn = {extras = ["standard"], version = "^0.30.6"}
 jinja2 = "^3.1.4"


### PR DESCRIPTION
## Summary
- move project dependencies under `[tool.poetry.dependencies]` to satisfy poetry schema

## Testing
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `pip install pre-commit` *(fails: could not connect to proxy)*
- `poetry check` *(fails: pyproject.toml changed; lock update required)*
- `poetry lock` *(fails: could not connect to pypi.org)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be538312b0832f816aaa3456c6243c