### PR TITLE
Refine creative router tests and add minimal backend scaffolding

### DIFF
--- a/apps/backend/db.py
+++ b/apps/backend/db.py
@@ -1,13 +1,50 @@
+"""Database utilities for the lightweight test environment.
+
+This module provides a minimal SQLAlchemy setup so that modules depending on
+``get_db`` or ``Base`` can be imported during tests.  The real project uses a
+more elaborate configuration, but for the purposes of unit tests an in-memory
+SQLite database is sufficient.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
 
 
-# Initialize tables on startup
+# SQLite database stored in the repository root.  ``check_same_thread`` is
+# required for SQLite when using the connection in different threads (e.g. the
+# test runner).
+DATABASE_URL = "sqlite:///./mindforge.db"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+# Base class for ORM models
+Base = declarative_base()
+
+
+def init_db(base: declarative_base = Base) -> None:
+    """Create database tables for all metadata defined on ``base``."""
+
+    base.metadata.create_all(bind=engine)
+
+
+# Initialize tables on import so that routers relying on them can be imported
+# without additional setup.
 init_db(Base)
 
 
-def get_db():
-    """FastAPI dependency for database sessions."""
+@contextmanager
+def get_db() -> Generator:
+    """FastAPI dependency that yields a database session."""
+
     db = SessionLocal()
     try:
         yield db
     finally:
         db.close()
+

--- a/apps/backend/schemas/__init__.py
+++ b/apps/backend/schemas/__init__.py
@@ -26,6 +26,13 @@ class ProjectQuestionCreate:
 
 
 @dataclass
+class ProjectQuestionUpdate:
+    """Schema used when updating a project question with an answer."""
+
+    answer: str
+
+
+@dataclass
 class CaseyQuestionResponse:
     """Represents a question returned to the Casey UI."""
 
@@ -38,4 +45,51 @@ class CaseyQuestionResponse:
     follow_up_questions: Optional[List[str]] = field(default=None)
 
 
-__all__ = ["ProjectQuestionCreate", "CaseyQuestionResponse", "ProjectType"]
+@dataclass
+class CreativeProjectCreate:
+    """Schema used when creating a new creative project."""
+
+    name: str
+    project_type: ProjectType
+    description: Optional[str] = None
+    original_filename: Optional[str] = None
+    file_path: Optional[str] = None
+    file_size: Optional[int] = None
+    mime_type: Optional[str] = None
+
+
+@dataclass
+class CreativeProject:
+    """Simple representation of a creative project."""
+
+    id: int
+    name: str
+    project_type: ProjectType
+    description: Optional[str] = None
+
+
+@dataclass
+class ProjectUploadResponse:
+    """Response returned after successfully uploading a project."""
+
+    project_id: int
+    filename: str
+
+
+@dataclass
+class ProjectAnalysisResponse:
+    """Minimal analysis response for uploaded projects."""
+
+    result: dict
+
+
+__all__ = [
+    "ProjectQuestionCreate",
+    "ProjectQuestionUpdate",
+    "CaseyQuestionResponse",
+    "CreativeProjectCreate",
+    "CreativeProject",
+    "ProjectUploadResponse",
+    "ProjectAnalysisResponse",
+    "ProjectType",
+]

--- a/test_creative_router.py
+++ b/test_creative_router.py
@@ -3,9 +3,10 @@ Simple test script for creative projects router functionality.
 Run this once FastAPI and other dependencies are installed.
 """
 
-import sys
 import os
+import sys
 from pathlib import Path
+import pytest
 
 # Add project root to path. The original script assumed the file lived three
 # directories below the project root which isn't the case in this kata.  This
@@ -21,147 +22,52 @@ sys.path.insert(0, str(project_root))
 
 def test_imports():
     """Test that all modules can be imported."""
-    print("Testing imports...")
-    
-    try:
-        from apps.backend.schemas import ProjectType, CreativeProjectCreate, ProjectUploadResponse
-        print("✅ Schemas imported successfully")
-    except Exception as e:
-        print(f"❌ Schemas import failed: {e}")
-        return False
-    
-    try:
-        from apps.backend.services.models import CreativeProject, ProjectQuestion
-        print("✅ Models imported successfully")
-    except Exception as e:
-        print(f"❌ Models import failed: {e}")
-        return False
-    
-    try:
-        from apps.backend.services.project_questioner import CaseyProjectQuestioner
-        print("✅ Project questioner imported successfully")
-    except Exception as e:
-        print(f"❌ Project questioner import failed: {e}")
-        return False
-    
-    try:
-        from apps.backend.services.creative_analyzer import CreativeProjectAnalyzer
-        print("✅ Creative analyzer imported successfully")
-    except Exception as e:
-        print(f"❌ Creative analyzer import failed: {e}")
-        return False
-    
-    return True
+    from apps.backend.schemas import (
+        ProjectType,
+        CreativeProjectCreate,
+        ProjectUploadResponse,
+    )
+    from apps.backend.services.models import CreativeProject, ProjectQuestion
+    from apps.backend.services.project_questioner import CaseyProjectQuestioner
+    from apps.backend.services.creative_analyzer import CreativeProjectAnalyzer
 
 def test_service_instantiation():
     """Test that services can be instantiated."""
-    print("\nTesting service instantiation...")
-    
-    try:
-        from apps.backend.services.project_questioner import CaseyProjectQuestioner
-        questioner = CaseyProjectQuestioner()
-        print("✅ CaseyProjectQuestioner instantiated successfully")
-        
-        # Test question templates
-        assert len(questioner.question_templates) > 0
-        print(f"✅ Question templates loaded: {len(questioner.question_templates)} project types")
-        
-    except Exception as e:
-        print(f"❌ CaseyProjectQuestioner failed: {e}")
-        return False
-    
-    try:
-        from apps.backend.services.creative_analyzer import CreativeProjectAnalyzer
-        analyzer = CreativeProjectAnalyzer()
-        print("✅ CreativeProjectAnalyzer instantiated successfully")
-        
-        # Test supported file types
-        assert len(analyzer.supported_image_types) > 0
-        print(f"✅ File type support loaded: {len(analyzer.supported_image_types)} image types")
-        
-    except Exception as e:
-        print(f"❌ CreativeProjectAnalyzer failed: {e}")
-        return False
-    
-    return True
+    from apps.backend.services.project_questioner import CaseyProjectQuestioner
+    from apps.backend.services.creative_analyzer import CreativeProjectAnalyzer
+
+    questioner = CaseyProjectQuestioner()
+    assert len(questioner.question_templates) > 0
+
+    analyzer = CreativeProjectAnalyzer()
+    assert len(analyzer.supported_image_types) > 0
 
 def test_router_import():
     """Test that the router can be imported."""
-    print("\nTesting router import...")
-    
-    try:
-        from apps.backend.routers.creative_projects import router
-        print("✅ Creative projects router imported successfully")
-        
-        # Check that routes are registered
-        routes = [route.path for route in router.routes]
-        expected_routes = [
-            "/upload",
-            "/projects",
-            "/projects/{project_id}",
-            "/projects/{project_id}/casey-question",
-            "/projects/{project_id}/answer",
-            "/projects/{project_id}/analyze",
-            "/projects/{project_id}/chat"
-        ]
-        
-        for expected_route in expected_routes:
-            full_route = f"/api/creative{expected_route}"
-            if any(expected_route in route for route in routes):
-                print(f"✅ Route registered: {expected_route}")
-            else:
-                print(f"❌ Route missing: {expected_route}")
-                return False
-        
-        return True
-        
-    except Exception as e:
-        print(f"❌ Router import failed: {e}")
-        return False
+    from apps.backend.routers.creative_projects import router
+
+    routes = [route.path for route in router.routes]
+    expected_routes = [
+        "/upload",
+        "/projects",
+        "/projects/{project_id}",
+        "/projects/{project_id}/casey-question",
+        "/projects/{project_id}/answer",
+        "/projects/{project_id}/analyze",
+        "/projects/{project_id}/chat",
+    ]
+
+    for expected_route in expected_routes:
+        assert any(
+            expected_route in route for route in routes
+        ), f"Route missing: {expected_route}"
 
 def test_app_integration():
     """Test that the router is properly integrated into the app."""
-    print("\nTesting app integration...")
-    
-    try:
-        # This would test the app integration but requires database setup
-        print("⚠️  App integration test requires database setup")
-        print("   Run with USE_DATABASE=true environment variable when dependencies are available")
-        return True
-        
-    except Exception as e:
-        print(f"❌ App integration test failed: {e}")
-        return False
-
-def main():
-    """Run all tests."""
-    print("🧪 Creative Projects Router Test Suite")
-    print("=" * 50)
-    
-    tests = [
-        test_imports,
-        test_service_instantiation,
-        test_router_import,
-        test_app_integration
-    ]
-    
-    passed = 0
-    total = len(tests)
-    
-    for test in tests:
-        if test():
-            passed += 1
-        print()
-    
-    print("=" * 50)
-    print(f"Test Results: {passed}/{total} tests passed")
-    
-    if passed == total:
-        print("🎉 All tests passed! Router is ready for use.")
-        return 0
-    else:
-        print("💥 Some tests failed. Check dependencies and setup.")
-        return 1
-
-if __name__ == "__main__":
-    exit(main())
+    if not os.getenv("USE_DATABASE"):
+        pytest.skip(
+            "App integration test requires database setup; "
+            "run with USE_DATABASE=true to enable"
+        )
+    # Integration logic would go here
+    assert True


### PR DESCRIPTION
## Summary
- replace boolean-returning tests with proper assertions and skip for DB-dependent test
- add lightweight SQLAlchemy database helper for tests
- provide minimal schema dataclasses so creative projects router can be imported

## Testing
- `pytest`
- `ruff check apps/backend/db.py apps/backend/schemas/__init__.py test_creative_router.py`


------
https://chatgpt.com/codex/tasks/task_e_68be5e41d470832f800abf38fb4d38b8