### PR TITLE
fix: correct poetry package-mode placement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "mindforge"
 version = "0.1.0"
 description = "MindForge monorepo"
 authors = ["MindForge Contributors"]
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -18,7 +19,6 @@ orjson = "^3.9.15"
 pypdf = "^4.0.1"
 python-dotenv = "^1.0.0"
 langchain = "^0.1.17"
-package-mode = false
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- move package-mode setting to [tool.poetry] to fix invalid dependency configuration

## Testing
- `poetry check`
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68be60574da4832f9aec14434144775b