### PR TITLE
fix(frontend): remove duplicate default export

### DIFF
--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import BusinessDashboard from './components/BusinessDashboard.jsx';
 import CreativeWorkspace from './components/CreativeWorkspace.jsx';
+import ProcessVisualizer from './components/ProcessVisualizer.jsx';
 import './components/BusinessDashboard.css';
 
 export default function App() {
@@ -46,5 +48,3 @@ export default function App() {
     </div>
   );
 }
-
-export default App;


### PR DESCRIPTION
## Summary
- fix App component default export duplication
- add missing imports for `useState` and `ProcessVisualizer`

## Testing
- `npm --workspace apps/frontend run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9db5d6c832f8f99bc88f9b8fd57