### PR TITLE
feat(frontend): introduce CaseyAi responsive dashboard

### DIFF
--- a/apps/frontend/src/App.jsx
+++ b/apps/frontend/src/App.jsx
@@ -1,50 +1,5 @@
-import { useState } from 'react';
-import BusinessDashboard from './components/BusinessDashboard.jsx';
-import CreativeWorkspace from './components/CreativeWorkspace.jsx';
-import ProcessVisualizer from './components/ProcessVisualizer.jsx';
-import './components/BusinessDashboard.css';
+import CaseyAi from './components/CaseyAi.jsx';
 
 export default function App() {
-  const [activeView, setActiveView] = useState('chat');
-
-  return (
-    <div className="app">
-      <aside className="sidebar">
-        <div className="sidebar-item" onClick={() => setActiveView('chat')}>
-          💬 New chat
-        </div>
-        <div className="sidebar-item">🔍 Search chats</div>
-        <div className="sidebar-item">📚 Library</div>
-        <div className="sidebar-item">📖 Docs</div>
-        <hr />
-        <div className="sidebar-item">📊 Data Analyst</div>
-        <div className="sidebar-item">🧠 MindForge AI</div>
-        <div className="sidebar-item">📄 Resume / Portfolio</div>
-        <div className="sidebar-item" onClick={() => setActiveView('business')}>
-          💼 Business Partner
-        </div>
-        <div className="sidebar-item" onClick={() => setActiveView('creative')}>
-          🎨 Creative Workspace
-        </div>
-      </aside>
-      <main className="main">
-        {activeView === 'chat' ? (
-          <>
-            <ProcessVisualizer />
-            <div className="welcome-overlay">
-              <h1>Ready when you are.</h1>
-              <div className="input-box">
-                <input type="text" placeholder="Ask anything" />
-                <button>+</button>
-              </div>
-            </div>
-          </>
-        ) : activeView === 'creative' ? (
-          <CreativeWorkspace />
-        ) : (
-          <BusinessDashboard />
-        )}
-      </main>
-    </div>
-  );
+  return <CaseyAi />;
 }

--- a/apps/frontend/src/components/CaseyAi.jsx
+++ b/apps/frontend/src/components/CaseyAi.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import BusinessDashboard from './BusinessDashboard.jsx';
+import CreativeWorkspace from './CreativeWorkspace.jsx';
+import ProcessVisualizer from './ProcessVisualizer.jsx';
+import './BusinessDashboard.css';
+
+export default function CaseyAi() {
+  const [activeView, setActiveView] = useState('chat');
+
+  return (
+    <div className="flex flex-col h-screen">
+      <nav className="flex justify-around bg-gray-800 text-white p-4 md:justify-start md:space-x-4">
+        <button className="hover:text-blue-300" onClick={() => setActiveView('chat')}>Chat</button>
+        <button className="hover:text-blue-300" onClick={() => setActiveView('creative')}>Creative</button>
+        <button className="hover:text-blue-300" onClick={() => setActiveView('business')}>Business</button>
+      </nav>
+      <main className="flex-1 overflow-auto">
+        {activeView === 'chat' ? (
+          <>
+            <ProcessVisualizer />
+            <div className="flex flex-col items-center justify-center p-4">
+              <h1 className="text-2xl mb-4 text-center">Ready when you are.</h1>
+              <div className="flex w-full max-w-md">
+                <input className="flex-1 p-2 border" type="text" placeholder="Ask anything" />
+                <button className="px-4 bg-blue-500 text-white">+</button>
+              </div>
+            </div>
+          </>
+        ) : activeView === 'creative' ? (
+          <CreativeWorkspace />
+        ) : (
+          <BusinessDashboard />
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace sidebar layout with CaseyAi component containing chat, creative, and business views
- add responsive top navigation for better mobile usability

## Testing
- `npm run build`
- `npm test` (fails: Missing script)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bede56eb48832f9c2ae381ae331c68